### PR TITLE
Implicit midpoint

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         version:
           - '1.6'
+          - '1.7'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: 1.3
+          version: 1.6
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RobotDynamics"
 uuid = "38ceca67-d8d3-44e8-9852-78a5596522e1"
 authors = ["Brian Jackson <bjack205@gmail.com>"]
-version = "0.4.3"
+version = "0.4.4"
 
 [deps]
 FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"

--- a/src/discrete_dynamics.jl
+++ b/src/discrete_dynamics.jl
@@ -62,10 +62,10 @@ Use [`propagate_dynamics!`](@ref) to conveniently save the next state directly i
 the state vector of another [`KnotPoint`](@ref).
 """
 abstract type DiscreteDynamics <: AbstractModel end
-@inline evaluate(model::DiscreteDynamics, x, u, p) =
-    discrete_dynamics(model, x, u, p.t, p.dt)
-@inline evaluate!(model::DiscreteDynamics, xn, x, u, p) =
-    discrete_dynamics!(model, xn, x, u, p.t, p.dt)
+@inline evaluate(model::DiscreteDynamics, z::AbstractKnotPoint) =
+    discrete_dynamics(model, z::AbstractKnotPoint)
+@inline evaluate!(model::DiscreteDynamics, xn, z::AbstractKnotPoint) =
+    discrete_dynamics!(model, xn, z::AbstractKnotPoint)
 
 """
     discrete_dynamics(model, z::AbstractKnotPoint)

--- a/src/discretized_dynamics.jl
+++ b/src/discretized_dynamics.jl
@@ -68,7 +68,21 @@ and control of `z1` (the knot point at the current time step).
 ## Treating an Implicit method as an Explicit method
 Implicit methods can be treated as an explicit integrator. In addition to the the 
 methods above that evaluate the dynamics error residual for the integrator, they 
-overload `evaluate`
+overload `discrete_dynamics`, `discrete_dynamics!`, and `jacobian`. The forward simulation
+functions `discrete_dynamics` and `discrete_dynamics!` use Newton's method. The dynamics 
+Jacobians are calculated using the Implicit Function Theorem.
+
+If the state and control vector passed to `jacobian!` are the same as the last call 
+to `jacobian!`, `discrete_dynamics` or `discrete_dynamics!` the Jacobians and matrix 
+factorization from the Newton solve are used to speed up the computation. Note that 
+the factorization is only cached for `InPlace` methods, not `StaticReturn`.
+
+## Defining an Implicit Integrator
+An implicit integrator should define the signatures above for `dynamics_error` and 
+`dynamics_error_jacobian!`. If the method wants to provide the functionality of an 
+explicit integrator (as described in the previous section), it should store internally 
+a [`ImplicitNewtonCache`](@ref), which must be returned using the getter function 
+`getnewtoncache`.
 """
 abstract type Implicit <: QuadratureRule end
 

--- a/src/discretized_dynamics.jl
+++ b/src/discretized_dynamics.jl
@@ -77,6 +77,12 @@ to `jacobian!`, `discrete_dynamics` or `discrete_dynamics!` the Jacobians and ma
 factorization from the Newton solve are used to speed up the computation. Note that 
 the factorization is only cached for `InPlace` methods, not `StaticReturn`.
 
+To call `jacobian!` on `DiscretizedDynamics` with an implicit dynamics model, it must be 
+called using the `ImplicitFunctionTheorem` method, which also specified the 
+[`DiffMethod`](@ref) that should be used to evaluate `dynamics_error_jacobian!`, e.g.
+
+    jacobian!(InPlace(), ImplicitFunctionTheorem(ForwardDiff), implicitmodel, J, y, z)
+
 ## Defining an Implicit Integrator
 An implicit integrator should define the signatures above for `dynamics_error` and 
 `dynamics_error_jacobian!`. If the method wants to provide the functionality of an 
@@ -122,7 +128,29 @@ differentiation method, for that matter) with the integrator, they are free to d
 own [`DiffMethod`](@ref) to dispatch on.
 
 ## Implicit Dynamics
+If an [`Implicit`](@ref) integrator is used, the interface changes slightly. The dynamics 
+residual is calculated and it's Jacobian are calculated using
 
+    dynamics_error(model, z2, z1)
+    dynamics_error!(model, y2, y1, z2, z1)
+    dynamics_error_jacobian!(sig, diff, model, J2, J1, y2, y1, z2, z1)
+
+Where the dynamics residual is stored in `y2` for the in-place version, and the Jacobians 
+with respect to the state and control at the next and current knot points are stored in `J2`
+and `J1`, respectively.
+
+Implicit dynamics integrators can also support the normal API 
+(see documentation for [`Implicit`](@ref)). Note that calls to `discrete_dynamics` will 
+use a Newton's solve to calculate the next state and calls to `jacobian!` will use the 
+Implicit Function Theorem. In order to use the implicit function theorem to get the 
+Jacobians, `jacobian!` must be called using the `ImplicitFunctionTheorem` 
+[`DiffMethod`](@ref), which also specifies the `DiffMethod` to use to on 
+`dynamics_error_jacobian!`.
+
+When using Newton's method during `discrete_dynamics`, the `DiffMethod` returned by 
+`default_diffmethod` for the continuous dynamics model is used to evaluate the 
+`dynamics_error_jacobian!`. There is no option to change this at run time, since 
+`discrete_dynamics` and `discrete_dynamics!` do not take a `DiffMethod` as an argument.
 """
 @autodiff struct DiscretizedDynamics{L,Q} <: DiscreteDynamics
     continuous_dynamics::L

--- a/src/discretized_dynamics.jl
+++ b/src/discretized_dynamics.jl
@@ -208,6 +208,14 @@ function jacobian!(sig::FunctionSignature, ::ImplicitFunctionTheorem{D}, model::
     jacobian!(integration(model), sig, D(), model, J, xn, z)
 end
 
+for sig in (:InPlace, :StaticReturn), diff in (:ForwardAD, :FiniteDifference, :UserDefined)
+    @eval begin
+        function jacobian!(::$sig, ::$diff, ::ImplicitDynamicsModel, J, xn, z)
+            throw(ArgumentError("Must call jacobian! on an ImplicitDynamicsModel with the ImplicitFunctionTheorem diff method. Got $($diff)."))
+        end
+    end
+end
+
 default_diffmethod(model::ImplicitDynamicsModel) = 
     ImplicitFunctionTheorem(default_diffmethod(model.continuous_dynamics))
 

--- a/src/functionbase.jl
+++ b/src/functionbase.jl
@@ -107,6 +107,14 @@ abstract type DiffMethod end
 struct ForwardAD <: DiffMethod end
 struct FiniteDifference <: DiffMethod end
 struct UserDefined <: DiffMethod end
+struct ImplicitFunctionTheorem{D<:DiffMethod} <: DiffMethod
+    function ImplicitFunctionTheorem(diff::D) where D <: DiffMethod
+        if D <: ImplicitFunctionTheorem
+            throw(ArgumentError("DiffMethod for ImplicitFunctionTheorem cannot also be ImplicitFunctionTheorem."))
+        end
+        new{D}()
+    end
+end
 default_diffmethod(::AbstractFunction) = UserDefined()
 default_signature(::AbstractFunction) = StaticReturn()
 

--- a/src/functionbase.jl
+++ b/src/functionbase.jl
@@ -91,6 +91,9 @@ methods are provided:
 * `FiniteDifference`: finite difference approximation using 
    [FiniteDiff.jl](https://github.com/JuliaDiff/FiniteDiff.jl)
 * `UserDefined`: analytical function defined by the user.
+* `ImplicitFunctionTheorem`: Only available for a [`DiscretizedDynamics`](@ref) model
+   with an an implicit integrator. Parameterized by the `DiffMethod` of the underlying 
+   continuous dynamics model. 
 
 The `UserDefined` method can be provided by defining any of the following methods 
 on your [`AbstractFunction`](@ref):

--- a/src/integration.jl
+++ b/src/integration.jl
@@ -414,7 +414,7 @@ end
 # Use Newton's method to solve for the next state for implicit dynamics
 function integrate(integrator::Implicit, model::ImplicitDynamicsModel, 
                    z::AbstractKnotPoint{Nx,Nu}) where {Nx,Nu} 
-    cache = integrator.cache
+    cache = getnewtoncache(integrator) 
     newton_iters = cache.newton_iters
     tol = cache.newton_tol
 
@@ -455,7 +455,7 @@ end
 
 function integrate!(integrator::Implicit, model::ImplicitDynamicsModel, xn, 
                     z::AbstractKnotPoint)
-    cache = integrator.cache
+    cache = getnewtoncache(integrator) 
     newton_iters = cache.newton_iters
     tol = cache.newton_tol
 
@@ -502,7 +502,7 @@ end
 function jacobian!(integrator::Implicit, ::StaticReturn, diff::DiffMethod, 
                    model::ImplicitDynamicsModel, J, y, z::AbstractKnotPoint{Nx,Nu}
                    ) where {Nx,Nu}
-    cache = integrator.cache
+    cache = getnewtoncache(integrator) 
     J2 = cache.J2
     J1 = cache.J1
     ix = SVector{Nx}(1:Nx)
@@ -525,7 +525,7 @@ end
 function jacobian!(integrator::Implicit, ::InPlace, diff::DiffMethod, 
                    model::ImplicitDynamicsModel, J, y, z::AbstractKnotPoint)
     n,m = dims(z)
-    cache = integrator.cache
+    cache = getnewtoncache(integrator) 
     J1 = cache.J1
 
     aresame = maxdiff(cache.z2, z) < √eps()
@@ -577,8 +577,8 @@ mutable struct ImplicitNewtonCache
         ipiv = zeros(BlasInt, n)
         A = zeros(n,n) 
         F = lu!(A, check=false)
-        iters = 10
-        tol = √eps()
+        iters = 10    # Default number of Newton iterations
+        tol = 1e-12   # Default Newton tolerance
         new(J2, J1, y2, y1, z2, ipiv, A, F, iters, tol)
     end
 end

--- a/src/integration.jl
+++ b/src/integration.jl
@@ -411,6 +411,161 @@ end
 # Implicit Methods
 ########################################
 
+function integrate(integrator::Implicit, model, z::AbstractKnotPoint{Nx,Nu}) where {Nx,Nu} 
+    # TODO: get these from some options
+    newton_iters = 10
+    tol = 1e-10
+
+    n,m = dims(z)
+    cache = integrator.cache
+    J2 = cache.J2
+    J1 = cache.J1
+    y2 = cache.y2
+    y1 = cache.y1
+    z1 = z
+    z2 = StaticKnotPoint(z)
+    xn = state(z2)
+    ix = SVector{Nx}(1:Nx) 
+
+    diff = default_diffmethod(model.continuous_dynamics)
+    for iter = 1:newton_iters
+        # Set the guess for the next state
+        z2 = setstate(z2, xn)
+
+        # Calculate the residual
+        r = dynamics_error(integrator, model.continuous_dynamics, z2, z1)
+
+        # Calculate the Jacobian wrt x2
+        dynamics_error_jacobian!(StaticReturn(), diff, model, 
+                                 J2, J1, y2, y1, z2, z1)
+        A = J2[ix, ix] 
+
+        if norm(r) < tol
+            break
+        end
+
+        # Get the step
+        F = lu(A)
+        dx = F \ r
+        xn -= dx
+    end
+    setdata!(cache.z2, getdata(z))  # copy input into cache for Jacobian check
+    return xn
+end
+
+function integrate!(integrator::Implicit, model, xn, z::AbstractKnotPoint)
+    # TODO: get these from some options
+    newton_iters = 10
+    tol = 1e-10
+
+    cache = integrator.cache
+    z1 = z
+    n,m = dims(z)
+    J2 = cache.J2
+    J1 = cache.J1
+    r = cache.y2
+    dx = cache.y1
+    z2 = cache.z2
+    ipiv = cache.ipiv
+    A = cache.A
+    Aview = @view J2[:, 1:n]
+
+    copyto!(z2, z1)
+    diff = default_diffmethod(model.continuous_dynamics)
+    for iter = 1:newton_iters
+        # Set the guess for the next state
+        setstate!(z2, xn)
+
+        # Calculate the residual
+        dynamics_error!(integrator, model.continuous_dynamics, r, dx, z2, z1)
+
+        if norm(r) < tol
+            break
+        end
+
+        # Calculate the Jacobian wrt x2
+        dynamics_error_jacobian!(InPlace(), diff, model, J2, J1, r, dx, z2, z1)
+        A .= Aview 
+
+        # Get the step
+        dx .= r
+        F = lu!(A, ipiv)
+        ldiv!(F, dx)
+
+        # Apply the step
+        xn .-= dx
+    end
+    setdata!(cache.z2, getdata(z))  # copy input to cache for Jacobian check
+end
+
+function jacobian!(integrator::Implicit, ::StaticReturn, diff::DiffMethod, 
+                   model::ImplicitDynamicsModel, J, y, z::AbstractKnotPoint{Nx,Nu}
+                   ) where {Nx,Nu}
+    cache = integrator.cache
+    J2 = cache.J2
+    J1 = cache.J1
+    ix = SVector{Nx}(1:Nx)
+
+    # Update Jacobian
+    aresame = maxdiff(cache.z2, z) < √eps()
+    if !aresame
+        @debug "Solving for next state to get Jacobian using IFT."
+        evaluate(model, z)
+    else
+        @debug "Using cached Static Factorization"
+    end
+    A2 = J2[ix,ix]
+    Jstatic = SMatrix{Nx,Nx+Nu}(J1)
+    J .= A2 \ Jstatic
+    J .*= -1
+    return
+end
+
+function jacobian!(integrator::Implicit, ::InPlace, diff::DiffMethod, 
+                   model::ImplicitDynamicsModel, J, y, z::AbstractKnotPoint)
+    n,m = dims(z)
+    cache = integrator.cache
+    J1 = cache.J1
+
+    aresame = maxdiff(cache.z2, z) < √eps()
+    local F
+    if !aresame
+        @debug "Solving for next state to get Jacobian using IFT."
+        y .= state(z)
+        evaluate!(model, y, z)
+    else
+        @debug "Using cached Factorization"
+    end
+    F = cache.F
+    J .= J1
+    J .*= -1
+    ldiv!(F, J)
+    return
+end
+
+mutable struct ImplicitNewtonCache
+    J2::Matrix{Float64}
+    J1::Matrix{Float64}
+    y2::Vector{Float64}
+    y1::Vector{Float64}
+    z2::StaticKnotPoint{Any,Any,Vector{Float64},Float64}
+    ipiv::Vector{BlasInt}
+    A::Matrix{Float64}
+    F::LinearAlgebra.LU{Float64, Matrix{Float64}} 
+    function ImplicitNewtonCache(n::Integer, m::Integer)
+        J2 = zeros(n,n+m)
+        J1 = zeros(n,n+m)
+        y2 = zeros(n)
+        y1 = zeros(n)
+        v = zeros(n+m)
+        z2 = StaticKnotPoint{Any,Any}(n, m, v, 0.0, NaN)
+        ipiv = zeros(BlasInt, n)
+        A = zeros(n,n) 
+        F = lu!(A, check=false)
+        new(J2, J1, y2, y1, z2, ipiv, A, F)
+    end
+end
+
 """
     ImplicitMidpoint
 
@@ -423,21 +578,10 @@ x_1 + h f(\\frac{1}{2}(x_1 + x_2), u_1, t + \\frac{1}{2} h) - x_2 = 0
 """
 struct ImplicitMidpoint <: Implicit
     xmid::ADVector{Float64}
-    J2::Matrix{Float64}
-    J1::Matrix{Float64}
-    y2::Vector{Float64}
-    y1::Vector{Float64}
-    z2::StaticKnotPoint{Any,Any,Vector{Float64},Float64}
-    ipiv::Vector{BlasInt}
+    cache::ImplicitNewtonCache
     function ImplicitMidpoint(n::Integer, m::Integer)
-        J2 = zeros(n,n+m)
-        J1 = zeros(n,n+m)
-        y2 = zeros(n)
-        y1 = zeros(n)
-        v = zeros(n+m)
-        z2 = StaticKnotPoint{Any,Any}(n, m, v, 0.0, NaN)
-        ipiv = zeros(BlasInt, n)
-        new(ADVector{Float64}(n), J2, J1, y2, y1, z2, ipiv)
+        cache = ImplicitNewtonCache(n, m)
+        new(ADVector{Float64}(n), cache)
     end
 end
 

--- a/src/integration.jl
+++ b/src/integration.jl
@@ -423,8 +423,21 @@ x_1 + h f(\\frac{1}{2}(x_1 + x_2), u_1, t + \\frac{1}{2} h) - x_2 = 0
 """
 struct ImplicitMidpoint <: Implicit
     xmid::ADVector{Float64}
+    J2::Matrix{Float64}
+    J1::Matrix{Float64}
+    y2::Vector{Float64}
+    y1::Vector{Float64}
+    z2::StaticKnotPoint{Any,Any,Vector{Float64},Float64}
+    ipiv::Vector{BlasInt}
     function ImplicitMidpoint(n::Integer, m::Integer)
-        new(ADVector{Float64}(n))
+        J2 = zeros(n,n+m)
+        J1 = zeros(n,n+m)
+        y2 = zeros(n)
+        y1 = zeros(n)
+        v = zeros(n+m)
+        z2 = StaticKnotPoint{Any,Any}(n, m, v, 0.0, NaN)
+        ipiv = zeros(BlasInt, n)
+        new(ADVector{Float64}(n), J2, J1, y2, y1, z2, ipiv)
     end
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -7,6 +7,20 @@ function Base.showerror(io::IO, err::NotImplementedError)
     print(io, err.msg)
 end
 
+"""
+    maxdiff(a, b)
+
+Get the maximum difference between vectors. Equivalent to the infinity norm of the 
+difference, but avoids forming the temporary difference vector.
+"""
+function maxdiff(a, b)
+    err = -Inf
+    for i = min(length(a), length(b))
+        err = max(err, abs(a[i] - b[i]))
+    end
+    return err
+end
+
 # Add non-allocating lu! method that allows you to pass in the pivot vector
 using LinearAlgebra: BlasFloat, BlasInt
 using LinearAlgebra.BLAS: @blasfunc

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,3 +6,31 @@ function Base.showerror(io::IO, err::NotImplementedError)
     print(io, "NotImplementedError: ")
     print(io, err.msg)
 end
+
+# Add non-allocating lu! method that allows you to pass in the pivot vector
+using LinearAlgebra: BlasFloat, BlasInt
+using LinearAlgebra.BLAS: @blasfunc
+const libblastrampoline = LinearAlgebra.LAPACK.libblastrampoline 
+for (getrf,elty) in ((:dgetrf_, :Float64), (:sgetrf, :Float32))
+    @eval begin
+        function LinearAlgebra.LAPACK.getrf!(A::AbstractMatrix{$elty}, ipiv::AbstractVector{BlasInt})
+            LinearAlgebra.require_one_based_indexing(A)
+            LinearAlgebra.chkstride1(A)
+            m, n = size(A)
+            @assert length(ipiv) == min(m, n)
+            lda  = max(1,stride(A, 2))
+            info = Ref{BlasInt}()
+            ccall((@blasfunc($getrf), libblastrampoline), Cvoid,
+                    (Ref{BlasInt}, Ref{BlasInt}, Ptr{$elty},
+                    Ref{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt}),
+                    m, n, A, lda, ipiv, info)
+            LAPACK.chkargsok(info[])
+            A, ipiv, info[] #Error code is stored in LU factorization type
+        end
+    end
+end
+function LinearAlgebra.lu!(A::StridedMatrix{T}, ipiv::AbstractVector{BlasInt}; check::Bool=true) where T
+    lpt = LAPACK.getrf!(A, ipiv)
+    check && LinearAlgebra.checknonsingular(lpt[3])
+    return LU{T,typeof(A)}(lpt[1], lpt[2], lpt[3])
+end

--- a/test/function_base_test.jl
+++ b/test/function_base_test.jl
@@ -154,6 +154,10 @@ z_ = copy(z.z)
 @test getstate(z, z_) isa SubArray 
 @test getcontrol(z, z_) isa SubArray 
 
+RD.evaluate(fun, zs)
+y = zeros(3)
+RD.evaluate!(fun, y, z)
+
 test_fun(fun)
 
 ##############################

--- a/test/function_base_test.jl
+++ b/test/function_base_test.jl
@@ -450,9 +450,9 @@ jacobian!(RD.StaticReturn(), RD.ForwardAD(), fun, J, y, z)
 jacobian!(RD.InPlace(), RD.ForwardAD(), fun, J, y, z)
 @test J ≈ J0
 jacobian!(RD.StaticReturn(), RD.FiniteDifference(), fun, J, y, z)
-@test J ≈ J0 atol=1e-2
+@test J ≈ J0 rtol=1e-2
 jacobian!(RD.InPlace(), RD.FiniteDifference(), fun, J, y, z)
-@test J ≈ J0 atol=1e-2
+@test J ≈ J0 rtol=1e-2
 
 @test RD.getinput(RD.functioninputs(fun), z) === control(z)
 run_alloc_tests && @test test_allocs(fun, zs) == 0

--- a/test/implicit_dynamics_test.jl
+++ b/test/implicit_dynamics_test.jl
@@ -1,0 +1,85 @@
+using Test
+using RobotDynamics
+using StaticArrays
+using ForwardDiff
+using LinearAlgebra
+using FiniteDiff
+using Random
+using Rotations
+const RD = RobotDynamics
+
+include("cartpole_model.jl")
+
+##
+function testcustomlu()
+    n,m = 4,2
+    J1 = randn(n, n+m)
+    A = @view J1[:,1:n]
+    A2 = copy(A)
+
+    ipiv = similar(A, BLAS.BlasInt, min(n, n+m))
+    # @allocated LAPACK.getrf!(A, ipiv)
+    allocs = @allocated F = lu!(A, ipiv)
+    F2 = lu!(A)
+    @test F2.L ≈ F2.L
+    @test F2.U ≈ F2.U
+    @test allocs == 0
+end
+testcustomlu()
+
+##
+model = Cartpole()
+integrator = RD.ImplicitMidpoint(model)
+dmodel = RD.DiscretizedDynamics(model, integrator)
+dmodel_rk4 = RD.DiscretizedDynamics(model, RD.RK4(model))
+n,m = RD.dims(model)
+x1 = zeros(n)
+u1 = fill(1.0, m)
+dt = 0.01
+z1 = KnotPoint{n,m}(x1, u1, 0.0, dt)
+x2_rk4 = RD.discrete_dynamics(dmodel_rk4, z1)
+
+function midpoint_residual(x2, z1)
+    n,m = RD.dims(z1)
+    v = zeros(eltype(x2), n+m)
+    z2 = RD.StaticKnotPoint(z1, v)
+    RD.setstate!(z2, x2)
+    RD.dynamics_error(dmodel, z2, z1)
+end
+
+function newton_solve(z1)
+    n,m = RD.dims(z1)
+    r(xn) = midpoint_residual(xn, z1)
+    # function r(xn)
+    #     v = zeros(eltype(xn), n+m)
+    #     z2 = RD.StaticKnotPoint(z1, v)
+    #     RD.setstate!(z2, xn)
+    #     RD.dynamics_error(integrator, model, z2, z1)
+    # ed
+
+    xn = copy(RD.state(z1))
+    for i = 1:10
+        res = r(xn)
+        if norm(res) < 1e-6
+            println("Converged in $i iterations.")
+            break
+        end
+
+        ∇r = ForwardDiff.jacobian(r, xn)
+        xn .-= ∇r\res
+    end
+    return xn
+end
+x2 = newton_solve(z1)
+norm(midpoint_residual(x2, z1)) < 1e-6
+
+# Try in-place evaluation
+x2_midpoint = copy(x1)
+RD.evaluate!(dmodel, x2_midpoint, z1)
+@test norm(midpoint_residual(x2_midpoint, z1)) < 1e-6
+
+function test_allocs(dmodel, z)
+    x2 = zeros(RD.state_dim(dmodel))
+    @allocated RD.evaluate!(dmodel, x2, z1)
+end
+@test test_allocs(dmodel, z1) == 0

--- a/test/implicit_dynamics_test.jl
+++ b/test/implicit_dynamics_test.jl
@@ -155,5 +155,5 @@ function test_implicit_allocs(dmodel, z::RD.AbstractKnotPoint{Nx,Nu}) where {Nx,
     return allocs
 end
 test_implicit_allocs(dmodel, z1)  # run once to compile non-logging versions
-@test test_implicit_allocs(dmodel, z1) == 0
+run_alloc_tests && @test test_implicit_allocs(dmodel, z1) == 0
 end

--- a/test/implicit_dynamics_test.jl
+++ b/test/implicit_dynamics_test.jl
@@ -120,6 +120,11 @@ for i = 1:4
     @test norm(Jfd - J) < 1e-4
 end
 
+@test_throws ArgumentError RD.jacobian!(RD.InPlace(), RD.ForwardAD(), dmodel, J, y, z1)
+@test_throws ArgumentError RD.jacobian!(RD.StaticReturn(), RD.ForwardAD(), dmodel, J, y, z1)
+@test_throws ArgumentError RD.jacobian!(RD.StaticReturn(), RD.UserDefined(), dmodel, J, y, z1)
+@test_throws ArgumentError RD.jacobian!(RD.InPlace(), RD.FiniteDifference(), dmodel, J, y, z1)
+
 ENV["JULIA_DEBUG"] = "RobotDynamics"
 z1.z .+= 1
 @test_logs (:debug, r"Solving for next") RD.jacobian!(RD.InPlace(), diff, dmodel, J, y, z1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,7 @@ end
     end
     @testset "Integration" begin
         include("integration_tests.jl")
+        include("implicit_dynamics_test.jl")
     end
     @testset "KnotPoints" begin
         include("knotpoints.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ include("cartpole_model.jl")
 # include("random_linear.jl")
 include("quadrotor.jl")
 
-const run_alloc_tests = !haskey(ENV, "CI") 
+const run_alloc_tests = !haskey(ENV, "CI") && !Sys.iswindows()
 
 ##
 @testset "Function Base" begin


### PR DESCRIPTION
Closes #19. 

Defines `discrete_dynamics`, `discrete_dynamics`, and `jacobian!` for `DiscretizedDynamics` models that use implicit integrators. Currently only `ImplicitMidpoint` is defined. These methods use Newton's method and the implicit function theorem to emulate the behavior expected by an explicit integrator. 

All methods are allocation-free for both static and in-place vector arguments / function signatures.

Each implicit integrator must store an instance of `ImplicitNewtonCache`, which provides the cache variables needed to compute the needed matrices / vectors. In order to calculate the Jacobian of a `DiscretizedModel` using an implicit integrator, the `ImplicitFunctionTheorem` `DiffMethod` must be used, which also specifies the diff method to be used to evaluate the 
Jacobian of implicit dynamics residual function, e.g. `ImplicitFunctionTheorem{ForwardAD}`, created as `ImplicitFunctionTheorem(ForwardAD())`

All methods assume the control at the next time step is the same as the control at the current time step (i.e. zero-order-hold).

An example of using the API:
```julia
using RobotDynamics
const RD = RobotDynamics

model = Cartpole()
integrator = RD.ImplicitMidpoint(model)
dmodel = RD.DiscretizedDynamics(model, integrator)
# OR 
dmodel = RD.DiscretizedDynamics{RD.ImplicitMidpoint}(model)

n,m = RD.dims(model)
x1,u1 = rand(model)   # generate some random state and control vectors
dt = 0.01
z1 = KnotPoint{n,m}(x1,u1,0.0,dt)
z1_static = KnotPoint{n,m}(SVector{n}(x1), SVector{m}(u1), 0.0, dt)
x2 = copy(x1)

# Solve for next state using Newton's method
RD.discrete_dynamics!(dmodel, x2, z1)
x2_static = RD.discrete_dynamics(dmodel, z1_static)

# Get the dynamics Jacobians
J = zeros(n, n+m)
diff = RD.default_diffmethod(dmodel)  
# OR 
diff = RD.ImplicitFunctionTheorem(ForwardAD())
RD.jacobian!(RD.InPlace(), diff, dmodel, J, xn, z1)
RD.jacobian!(RD.StaticReturn(), diff, dmodel, J, xn, z1_static)
```